### PR TITLE
Workaround conda-build 1.20.1

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,6 +64,7 @@ install:
     - cmd: conda config --add channels http://conda.binstar.org/conda-forge
     - cmd: conda info
     - cmd: conda install -n root --quiet --yes conda-build anaconda-client jinja2 setuptools
+    - cmd: conda install --yes conda-build=1.20.0
 
 # Skip .NET project specific build phase.
 build: off


### PR DESCRIPTION
Downgrade to `conda-build 1.20.0` on Windows.
