### PR TITLE
Require backports

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ To manage the continuous integration and simplify feedstock maintenance
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
+For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 713e7a8228ae80341c70586d1cc0a8caa5207346927e23d09dcbcaf18eadec80
 
 build:
-  number: 2
+  number: 3
   noarch: python
   script: pip install --no-deps .
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,8 +17,10 @@ requirements:
   build:
     - python
     - pip
+    - backports
   run:
     - python
+    - backports
 
 test:
   imports:


### PR DESCRIPTION
Pulls in the `backports` package, which ensures the `backports` namespace is available in advance.